### PR TITLE
Add from regexes to circuits

### DIFF
--- a/circuits-circom/scripts/circuit.env.example
+++ b/circuits-circom/scripts/circuit.env.example
@@ -1,5 +1,5 @@
-CIRCUIT_NAME=twitter
+CIRCUIT_NAME=venmo_send
 BUILD_DIR="../build/$CIRCUIT_NAME"
 PTAU_DIR="../.."
 PTAU=23
-RAPIDSNARK_PATH="./../../rapidsnark/build/prover"
+RAPIDSNARK_PATH=./../../rapidsnark/build/prover

--- a/circuits-circom/scripts/generate_input.ts
+++ b/circuits-circom/scripts/generate_input.ts
@@ -219,7 +219,7 @@ export async function getCircuitInputs(
     const venmo_receive_id_idx = (Buffer.from(bodyRemaining).indexOf(RECEIVE_ID_SELECTOR) + RECEIVE_ID_SELECTOR.length).toString();
     const email_timestamp_idx = (raw_header.length - trimStrByStr(raw_header, "t=").length).toString();
 
-    console.log("Indexes into for venmo receive email are: ", email_timestamp_idx, venmo_receive_id_idx);
+    console.log("Indexes into for venmo receive email are: ", email_from_idx, email_timestamp_idx, venmo_receive_id_idx);
 
     circuitInputs = {
       in_padded,
@@ -233,16 +233,16 @@ export async function getCircuitInputs(
       // venmo specific indices
       email_timestamp_idx,
       venmo_receive_id_idx,
+      email_from_idx,
       // IDs
-      order_id,
-      // claim_id
+      order_id
     };
   } else if (circuit === CircuitType.EMAIL_VENMO_SEND) {
     const SEND_ID_SELECTOR = Buffer.from(STRING_PRESELECTOR_FOR_EMAIL_TYPE);
     const venmo_send_id_idx = (Buffer.from(bodyRemaining).indexOf(SEND_ID_SELECTOR) + SEND_ID_SELECTOR.length).toString();
 
     const venmo_amount_idx = (raw_header.length - trimStrByStr(email_subject, "$").length).toString();
-    console.log("Indexes into for venmo send email are: ", venmo_amount_idx, venmo_send_id_idx);
+    console.log("Indexes into for venmo send email are: ", email_from_idx, venmo_amount_idx, venmo_send_id_idx);
 
     circuitInputs = {
       in_padded,
@@ -256,9 +256,9 @@ export async function getCircuitInputs(
       // venmo specific indices
       venmo_amount_idx,
       venmo_send_id_idx,
+      email_from_idx,
       // IDs
       order_id,
-      // claim_id
     };
   } else if (circuit === CircuitType.EMAIL_TWITTER) {
     const USERNAME_SELECTOR = Buffer.from(STRING_PRESELECTOR_FOR_EMAIL_TYPE);

--- a/circuits-circom/test/venmo_send.js
+++ b/circuits-circom/test/venmo_send.js
@@ -80,7 +80,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should generate witnesses", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -94,7 +94,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct packed from email", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -127,7 +127,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct packed amount", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -160,7 +160,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct packed offramper id", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -193,7 +193,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct hashed offramper id", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -215,7 +215,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct modulus", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -235,7 +235,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct signature", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);
@@ -255,7 +255,7 @@ describe("Venmo send WASM tester", function () {
 
     it("Should return the correct order id", async () => {
         // To preserve privacy of emails, load inputs generated using `yarn gen-input`. Ping us if you want an example venmo_send.eml to run tests 
-        // Otherwise, you can download the original eml from any Venmo receive payment transaction
+        // Otherwise, you can download the original eml from any Venmo send payment transaction
         const venmo_path = path.join(__dirname, "../inputs/input_venmo_send.json");
         const jsonString = fs.readFileSync(venmo_path, "utf8");
         const input = JSON.parse(jsonString);

--- a/circuits-circom/venmo_receive.circom
+++ b/circuits-circom/venmo_receive.circom
@@ -1,16 +1,8 @@
 pragma circom 2.1.5;
 
-include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/poseidon.circom";
-include "@zk-email/circuits/helpers/sha.circom";
-include "@zk-email/circuits/helpers/rsa.circom";
-include "@zk-email/circuits/helpers/base64.circom";
-include "@zk-email/circuits/helpers/extract.circom";
 include "@zk-email/circuits/email-verifier.circom";
-
 include "@zk-email/circuits/regexes/from_regex.circom";
-include "@zk-email/circuits/regexes/tofrom_domain_regex.circom";
-include "@zk-email/circuits/regexes/body_hash_regex.circom";
 include "./regexes/venmo_receive_id.circom";
 include "./regexes/venmo_timestamp.circom";
 
@@ -25,10 +17,8 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     signal input signature[k]; // rsa signature. split up into k parts of n bits each.
     signal input in_len_padded_bytes; // length of in email data including the padding, which will inform the sha256 block length
 
-
     // Base 64 body hash variables
     signal input body_hash_idx;
-
     // The precomputed_sha value is the Merkle-Damgard state of our SHA hash uptil our first regex match which allows us to save SHA constraints by only hashing the relevant part of the body
     signal input precomputed_sha[32];
     // Suffix of the body after precomputed SHA

--- a/circuits-circom/venmo_receive.circom
+++ b/circuits-circom/venmo_receive.circom
@@ -14,11 +14,6 @@ include "@zk-email/circuits/regexes/body_hash_regex.circom";
 include "./regexes/venmo_receive_id.circom";
 include "./regexes/venmo_timestamp.circom";
 
-// Here, n and k are the biginteger parameters for RSA
-// This is because the number is chunked into k pack_size of n bits each
-// Max header bytes shouldn't need to be changed much per email,
-// but the max mody bytes may need to be changed to be larger if the email has a lot of i.e. HTML formatting
-// TODO: split into header and body
 template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(max_header_bytes % 64 == 0);
     assert(max_body_bytes % 64 == 0);
@@ -34,33 +29,37 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     // Base 64 body hash variables
     signal input body_hash_idx;
 
-    // Precomputed sha vars for big body hashing
-    // Next 3 signals are for decreasing SHA constraints for parsing out information from the in-body text
-    // The precomputed_sha value is the Merkle-Damgard state of our SHA hash uptil our first regex match
-    // This allows us to save a ton of SHA constraints by only hashing the relevant part of the body
-    // It doesn't have an impact on security since a user must have known the pre-image of a signed message to be able to fake it
-    // The lower two body signals describe the suffix of the body that we care about
-    // The part before these signals, a significant prefix of the body, has been pre-hashed into precomputed_sha.
+    // The precomputed_sha value is the Merkle-Damgard state of our SHA hash uptil our first regex match which allows us to save SHA constraints by only hashing the relevant part of the body
     signal input precomputed_sha[32];
+    // Suffix of the body after precomputed SHA
     signal input in_body_padded[max_body_bytes];
+    // Length of the body after precomputed SHA
     signal input in_body_len_padded_bytes;
 
     EmailVerifier(max_header_bytes, max_body_bytes, n, k, 0)(in_padded, modulus, signature, in_len_padded_bytes, body_hash_idx, precomputed_sha, in_body_padded, in_body_len_padded_bytes);
 
+    // FROM HEADER REGEX: 736,553 constraints
+    // TODO: we set max len to 30 for all public outputs below for ease of use in the verifier contract for now
+    // This extracts the from email, and the precise regex format can be viewed in the README
+    var max_email_from_len = 30;
+    var max_email_from_packed_bytes = count_packed(max_email_from_len, pack_size);
+    assert(max_email_from_packed_bytes < max_header_bytes);
 
-    //
-    // CUSTOM REGEXES
-    //
+    signal input email_from_idx;
+    signal output reveal_email_from_packed[max_email_from_packed_bytes]; // packed into 7-bytes
+
+    signal (from_regex_out, from_regex_reveal[max_header_bytes]) <== FromRegex(max_header_bytes)(in_padded);
+    from_regex_out === 1;
+    reveal_email_from_packed <== ShiftAndPack(max_header_bytes, max_email_from_len, pack_size)(from_regex_reveal, email_from_idx);
 
     // TIMESTAMP REGEX: [x]
-    // TODO: we set max email amount len to 30 for all public outputs below for ease of use in the verifier contract for now
     // We will optimize the size later on
     var max_email_timestamp_len = 30;
     var max_email_timestamp_packed_bytes = count_packed(max_email_timestamp_len, pack_size);
     assert(max_email_timestamp_packed_bytes < max_header_bytes);
 
     signal input email_timestamp_idx;
-    signal output reveal_email_timestamp_packed[max_email_timestamp_packed_bytes]; // packed into 7-bytes. TODO: make this rotate to take up even less space
+    signal output reveal_email_timestamp_packed[max_email_timestamp_packed_bytes]; // packed into 7-bytes
 
     signal timestamp_regex_out, timestamp_regex_reveal[max_header_bytes];
     (timestamp_regex_out, timestamp_regex_reveal) <== VenmoTimestampRegex(max_header_bytes)(in_padded);
@@ -68,9 +67,9 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
 
     // PACKING: 16,800 constraints (Total: [x])
     reveal_email_timestamp_packed <== ShiftAndPack(max_header_bytes, max_email_timestamp_len, pack_size)(timestamp_regex_reveal, email_timestamp_idx);
-    
-    
+
     // VENMO RECEIVE ONRAMPER ID REGEX: [x]
+    // We will optimize the size later on
     var max_venmo_receive_len = 30;
     var max_venmo_receive_packed_bytes = count_packed(max_venmo_receive_len, pack_size); // ceil(max_num_bytes / 7)
     
@@ -91,7 +90,6 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
         hash.inputs[i] <== reveal_venmo_receive_packed[i];
     }
     signal output packed_onramper_id_hashed <== hash.out;
-    // log("Hash of packed Venmo Onramper ID", packed_onramper_id_hashed);
 
     // The following signals do not take part in any computation, but tie the proof to a specific order_id to prevent replay attacks and frontrunning.
     // https://geometry.xyz/notebook/groth16-malleability
@@ -107,6 +105,6 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
 // * max_header_bytes = 1024 is the max number of bytes in the header
 // * max_body_bytes = 6400 is the max number of bytes in the body after precomputed slice
 // * n = 121 is the number of bits in each chunk of the modulus (RSA parameter)
-// * k = 9 is the number of chunks in the modulus (RSA parameter)
+// * k = 17 is the number of chunks in the modulus (RSA parameter)
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
 component main { public [ modulus, signature, order_id ] } = VenmoReceiveEmail(1024, 6400, 121, 17, 7);

--- a/circuits-circom/venmo_send.circom
+++ b/circuits-circom/venmo_send.circom
@@ -1,23 +1,11 @@
 pragma circom 2.1.5;
 
-include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/poseidon.circom";
-include "@zk-email/circuits/helpers/sha.circom";
-include "@zk-email/circuits/helpers/rsa.circom";
-include "@zk-email/circuits/helpers/base64.circom";
-include "@zk-email/circuits/helpers/extract.circom";
-
+include "@zk-email/circuits/email-verifier.circom";
 include "@zk-email/circuits/regexes/from_regex.circom";
-include "@zk-email/circuits/regexes/tofrom_domain_regex.circom";
-include "@zk-email/circuits/regexes/body_hash_regex.circom";
 include "./regexes/venmo_send_id.circom";
 include "./regexes/venmo_amount.circom";
 
-// Here, n and k are the biginteger parameters for RSA
-// This is because the number is chunked into k pack_size of n bits each
-// Max header bytes shouldn't need to be changed much per email,
-// but the max mody bytes may need to be changed to be larger if the email has a lot of i.e. HTML formatting
-// TODO: split into header and body
 template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(max_header_bytes % 64 == 0);
     assert(max_body_bytes % 64 == 0);
@@ -29,90 +17,33 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     signal input signature[k]; // rsa signature. split up into k parts of n bits each.
     signal input in_len_padded_bytes; // length of in email data including the padding, which will inform the sha256 block length
 
-    // Identity commitment variables
-    // (note we don't need to constrain the + 1 due to https://geometry.xyz/notebook/groth16-malleability)
-    // signal input address;
-
     // Base 64 body hash variables
-    var LEN_SHA_B64 = 44;     // ceil(32 / 3) * 4, due to base64 encoding.
     signal input body_hash_idx;
-
-    // SHA HEADER: 506,670 constraints
-    // This calculates the SHA256 hash of the header, which is the "base_msg" that is RSA signed.
-    // The header signs the fields in the "h=Date:From:To:Subject:MIME-Version:Content-Type:Message-ID;"
-    // section of the "DKIM-Signature:"" line, along with the body hash.
-    // Note that nothing above the "DKIM-Signature:" line is signed.
-    signal sha[256] <== Sha256Bytes(max_header_bytes)(in_padded, in_len_padded_bytes);
-    var msg_len = (256 + n) \ n;
-
-    component base_msg[msg_len];
-    for (var i = 0; i < msg_len; i++) {
-        base_msg[i] = Bits2Num(n);
-    }
-    for (var i = 0; i < 256; i++) {
-        base_msg[i \ n].in[i % n] <== sha[255 - i];
-    }
-    for (var i = 256; i < n * msg_len; i++) {
-        base_msg[i \ n].in[i % n] <== 0;
-    }
-
-    // VERIFY RSA SIGNATURE: 149,251 constraints
-    // The fields that this signature actually signs are defined as the body and the values in the header
-    component rsa = RSAVerify65537(n, k);
-    for (var i = 0; i < msg_len; i++) {
-        rsa.base_message[i] <== base_msg[i].out;
-    }
-    for (var i = msg_len; i < k; i++) {
-        rsa.base_message[i] <== 0;
-    }
-    rsa.modulus <== modulus;
-    rsa.signature <== signature;
-
-    // BODY HASH REGEX: 617,597 constraints
-    // This extracts the body hash from the header (i.e. the part after bh= within the DKIM-signature section)
-    // which is used to verify the body text matches this signed hash + the signature verifies this hash is legit
-    signal (bh_regex_out, bh_reveal[max_header_bytes]) <== BodyHashRegex(max_header_bytes)(in_padded);
-    bh_regex_out === 1;
-    signal shifted_bh_out[LEN_SHA_B64] <== VarShiftLeft(max_header_bytes, LEN_SHA_B64)(bh_reveal, body_hash_idx);
-    // log(body_hash_regex.out);
-
-
-    // SHA BODY: 760,142 constraints
-
-    // Precomputed sha vars for big body hashing
-    // Next 3 signals are for decreasing SHA constraints for parsing out information from the in-body text
-    // The precomputed_sha value is the Merkle-Damgard state of our SHA hash uptil our first regex match
-    // This allows us to save a ton of SHA constraints by only hashing the relevant part of the body
-    // It doesn't have an impact on security since a user must have known the pre-image of a signed message to be able to fake it
-    // The lower two body signals describe the suffix of the body that we care about
-    // The part before these signals, a significant prefix of the body, has been pre-hashed into precomputed_sha.
+    // The precomputed_sha value is the Merkle-Damgard state of our SHA hash uptil our first regex match which allows us to save SHA constraints by only hashing the relevant part of the body
     signal input precomputed_sha[32];
+    // Suffix of the body after precomputed SHA
     signal input in_body_padded[max_body_bytes];
+    // Length of the body after precomputed SHA
     signal input in_body_len_padded_bytes;
 
-    // This verifies that the hash of the body, when calculated from the precomputed part forwards,
-    // actually matches the hash in the header
-    signal sha_body_out[256] <== Sha256BytesPartial(max_body_bytes)(in_body_padded, in_body_len_padded_bytes, precomputed_sha);
-    signal sha_b64_out[32] <== Base64Decode(32)(shifted_bh_out);
+    EmailVerifier(max_header_bytes, max_body_bytes, n, k, 0)(in_padded, modulus, signature, in_len_padded_bytes, body_hash_idx, precomputed_sha, in_body_padded, in_body_len_padded_bytes);
 
-    // When we convert the manually hashed email sha_body into bytes, it matches the
-    // base64 decoding of the final hash state that the signature signs (sha_b64)
-    component sha_body_bytes[32];
-    for (var i = 0; i < 32; i++) {
-        sha_body_bytes[i] = Bits2Num(8);
-        for (var j = 0; j < 8; j++) {
-            sha_body_bytes[i].in[7 - j] <== sha_body_out[i * 8 + j];
-        }
-        sha_body_bytes[i].out === sha_b64_out[i];
-    }
+    // FROM HEADER REGEX: 736,553 constraints
+    // TODO: we set max len to 30 for all public outputs below for ease of use in the verifier contract for now
+    // This extracts the from email, and the precise regex format can be viewed in the README
+    var max_email_from_len = 30;
+    var max_email_from_packed_bytes = count_packed(max_email_from_len, pack_size);
+    assert(max_email_from_packed_bytes < max_header_bytes);
 
-    //
-    // CUSTOM REGEXES
-    //
+    signal input email_from_idx;
+    signal output reveal_email_from_packed[max_email_from_packed_bytes]; // packed into 7-bytes
+
+    signal (from_regex_out, from_regex_reveal[max_header_bytes]) <== FromRegex(max_header_bytes)(in_padded);
+    from_regex_out === 1;
+    reveal_email_from_packed <== ShiftAndPack(max_header_bytes, max_email_from_len, pack_size)(from_regex_reveal, email_from_idx);
 
     // VENMO SEND AMOUNT REGEX: [x]
-    // TODO: we set max email amount len to 30 for all public outputs below for ease of use in the verifier contract for now
-    // We will optimize the size later on
+    // TODO We will optimize the size later on
     var max_email_amount_len = 30;
     var max_email_amount_packed_bytes = count_packed(max_email_amount_len, pack_size);
     assert(max_email_amount_packed_bytes < max_header_bytes);
@@ -127,6 +58,7 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     reveal_email_amount_packed <== ShiftAndPack(max_header_bytes, max_email_amount_len, pack_size)(amount_regex_reveal, venmo_amount_idx);
 
     // VENMO SEND OFFRAMPER ID REGEX: [x]
+    // TODO We will optimize the size later on
     var max_venmo_send_len = 30;
     var max_venmo_send_packed_bytes = count_packed(max_venmo_send_len, pack_size); // ceil(max_num_bytes / 7)
     
@@ -147,23 +79,12 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
         hash.inputs[i] <== reveal_venmo_send_packed[i];
     }
     signal output packed_offramper_id_hashed <== hash.out;
-    log("Hash of packed Venmo offramper ID", packed_offramper_id_hashed);
-
-    // Nullifier
-    // Packed SHA256 hash of the email header and body hash (the part that is signed upon)
-    signal output nullifier[msg_len];
-    for (var i = 0; i < msg_len; i++) {
-        nullifier[i] <== base_msg[i].out;
-    }
 
     // The following signals do not take part in any computation, but tie the proof to a specific order_id & claim_id to prevent replay attacks and frontrunning.
     // https://geometry.xyz/notebook/groth16-malleability
     signal input order_id;
-    // signal input claim_id;
     signal order_id_squared;
-    // signal claim_id_squared;
     order_id_squared <== order_id * order_id;
-    // claim_id_squared <== claim_id * claim_id;
 }
 
 // In circom, all output signals of the main component are public (and cannot be made private), the input signals of the main component are private if not stated otherwise using the keyword public as above. The rest of signals are all private and cannot be made public.
@@ -171,8 +92,8 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
 
 // Args:
 // * max_header_bytes = 1024 is the max number of bytes in the header
-// * max_body_bytes = 6400 is the max number of bytes in the body after precomputed slice
+// * max_body_bytes = 5952 is the max number of bytes in the body after precomputed slice
 // * n = 121 is the number of bits in each chunk of the modulus (RSA parameter)
-// * k = 9 is the number of chunks in the modulus (RSA parameter)
+// * k = 17 is the number of chunks in the modulus (RSA parameter)
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
-component main { public [ modulus, order_id ] } = VenmoSendEmail(1024, 5952, 121, 17, 7);
+component main { public [ modulus, signature, order_id ] } = VenmoSendEmail(1024, 5952, 121, 17, 7);


### PR DESCRIPTION
To make it difficult for malicious employees of Venmo with a @venmo.com email to fake an email by copying the exact same html from the, we extract the from email and ensure in the smart contract that it is from `venmo@venmo.com`

This does not make emails fully safe, because malicious employees can trigger a SendGrid, Twilio etc which will send emails from venmo@venmo.com

Tasks
* Update venmo receive circuit
* Update venmo send circuit
* Update generate inputs script
* Add tests for venmo send circuit
* Cleanup comments
* Cleanup tests

TODOs
- Generate new proving keys
- Generate new solidity verifier
- Generate example calldata