### PR TITLE
Brian/add fee

### DIFF
--- a/contracts/contracts/Ramp.sol
+++ b/contracts/contracts/Ramp.sol
@@ -118,6 +118,7 @@ contract Ramp is Ownable {
     uint256 internal constant PRECISE_UNIT = 1e18;
     uint256 internal constant MAX_DEPOSITS = 5;       // An account can only have max 5 different deposit parameterizations to prevent locking funds
     uint256 constant CIRCOM_PRIME_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant MAX_SUSTAINABILITY_FEE = 5e16;   // 5% max sustainability fee
     
     /* ============ State Variables ============ */
     IERC20 public immutable usdc;                               // USDC token contract
@@ -523,9 +524,11 @@ contract Ramp is Ownable {
      * @notice GOVERNANCE ONLY: Updates the sustainability fee. Fee updates are subject to a timelock in order to give users
      * enough time to react to proposed fee changes.
      *
-     * @param _fee   The new sustainability fee
+     * @param _fee   The new sustainability fee in precise units (10**18, ie 10% = 1e17)
      */
     function setSustainabilityFee(uint256 _fee) external onlyOwner {
+        require(_fee <= MAX_SUSTAINABILITY_FEE, "Fee cannot be greater than max fee");
+        
         sustainabilityFee = _fee;
         emit SustainabilityFeeUpdated(_fee);
     }

--- a/contracts/contracts/Ramp.sol
+++ b/contracts/contracts/Ramp.sol
@@ -537,8 +537,7 @@ contract Ramp is Ownable {
     }
 
     /**
-     * @notice GOVERNANCE ONLY: Updates the sustainability fee. Fee updates are subject to a timelock in order to give users
-     * enough time to react to proposed fee changes.
+     * @notice GOVERNANCE ONLY: Updates the sustainability fee. This fee is charged to on-rampers upon a successful on-ramp.
      *
      * @param _fee   The new sustainability fee in precise units (10**18, ie 10% = 1e17)
      */

--- a/contracts/deploy/deploy_contracts.ts
+++ b/contracts/deploy/deploy_contracts.ts
@@ -27,6 +27,10 @@ const INTENT_EXPIRATION_PERIOD = {
   "localhost": ONE_DAY_IN_SECONDS,
   "goerli": ONE_DAY_IN_SECONDS,
 };
+const ONRAMP_COOL_DOWN_PERIOD = {
+  "localhost": ONE_DAY_IN_SECONDS,
+  "goerli": ONE_DAY_IN_SECONDS,
+};
 const SUSTAINABILITY_FEE = {
   "localhost": ether(.001),
   "goerli": ether(.001),
@@ -75,6 +79,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       MIN_DEPOSIT_AMOUNT[network],
       MAX_ONRAMP_AMOUNT[network],
       INTENT_EXPIRATION_PERIOD[network],
+      ONRAMP_COOL_DOWN_PERIOD[network],
       SUSTAINABILITY_FEE[network],
       SUSTAINABILITY_FEE_RECIPIENT[network] != "" ? SUSTAINABILITY_FEE_RECIPIENT[network] : deployer,
     ],

--- a/contracts/deploy/deploy_contracts.ts
+++ b/contracts/deploy/deploy_contracts.ts
@@ -9,7 +9,7 @@ import { BigNumber } from "ethers";
 
 const circom = require("circomlibjs");
 
-import { usdc } from "../utils/common/units";
+import { ether, usdc } from "../utils/common/units";
 
 const SERVER_KEY_HASH = "0x2cf6a95f35c0d2b6160f07626e9737449a53d173d65d1683263892555b448d8f";
 
@@ -26,6 +26,14 @@ const MAX_ONRAMP_AMOUNT = {
 const INTENT_EXPIRATION_PERIOD = {
   "localhost": ONE_DAY_IN_SECONDS,
   "goerli": ONE_DAY_IN_SECONDS,
+};
+const SUSTAINABILITY_FEE = {
+  "localhost": ether(.001),
+  "goerli": ether(.001),
+};
+const SUSTAINABILITY_FEE_RECIPIENT = {
+  "localhost": "",
+  "goerli": "",
 };
 const USDC = {};
 const USDC_MINT_AMOUNT = usdc(1000000);
@@ -66,7 +74,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       poseidon.address,
       MIN_DEPOSIT_AMOUNT[network],
       MAX_ONRAMP_AMOUNT[network],
-      INTENT_EXPIRATION_PERIOD[network]
+      INTENT_EXPIRATION_PERIOD[network],
+      SUSTAINABILITY_FEE[network],
+      SUSTAINABILITY_FEE_RECIPIENT[network] != "" ? SUSTAINABILITY_FEE_RECIPIENT[network] : deployer,
     ],
   });
   console.log("Ramp deployed...");

--- a/contracts/test/ramp.spec.ts
+++ b/contracts/test/ramp.spec.ts
@@ -1596,7 +1596,7 @@ describe("Ramp", () => {
       });
     });
 
-    describe.only("#setSustainabilityFee", async () => {
+    describe("#setSustainabilityFee", async () => {
       let subjectSustainabilityFee: BigNumber;
       let subjectCaller: Account;
 
@@ -1627,6 +1627,16 @@ describe("Ramp", () => {
         expect(tx).to.emit(ramp, "SustainabilityFeeUpdated").withArgs(subjectSustainabilityFee);
       });
 
+      describe("when the fee exceeds the max sustainability fee", async () => {
+        beforeEach(async () => {
+          subjectSustainabilityFee = ether(.1);
+        });
+
+        it("should revert", async () => {
+          await expect(subject()).to.be.revertedWith("Fee cannot be greater than max fee");
+        });
+      });
+
       describe("when the caller is not the owner", async () => {
         beforeEach(async () => {
           subjectCaller = onRamper;
@@ -1638,7 +1648,7 @@ describe("Ramp", () => {
       });
     });
 
-    describe.only("#setSustainabilityFeeRecipient", async () => {
+    describe("#setSustainabilityFeeRecipient", async () => {
       let subjectSustainabilityFeeRecipient: Address;
       let subjectCaller: Account;
 

--- a/contracts/test/ramp.spec.ts
+++ b/contracts/test/ramp.spec.ts
@@ -906,7 +906,7 @@ describe("Ramp", () => {
         beforeEach(async () => {
           await subject();
 
-          await blockchain.increaseTimeAsync(ONE_DAY_IN_SECONDS.add(1).toNumber());
+          await blockchain.increaseTimeAsync(ONE_DAY_IN_SECONDS.add(10).toNumber());
 
           await ramp.connect(onRamper.wallet).signalIntent(depositId, usdc(50), receiver.address);
           const currentTimestamp = await blockchain.getCurrentTimestamp();

--- a/contracts/test/ramp.spec.ts
+++ b/contracts/test/ramp.spec.ts
@@ -906,8 +906,6 @@ describe("Ramp", () => {
         beforeEach(async () => {
           await subject();
 
-          await blockchain.increaseTimeAsync(ONE_DAY_IN_SECONDS.add(10).toNumber());
-
           await ramp.connect(onRamper.wallet).signalIntent(depositId, usdc(50), receiver.address);
           const currentTimestamp = await blockchain.getCurrentTimestamp();
           intentHash = calculateIntentHash(await calculateVenmoIdHash("2"), depositId, currentTimestamp);
@@ -1108,6 +1106,8 @@ describe("Ramp", () => {
       describe("when the intent zeroes out the deposit", async () => {
         beforeEach(async () => {
           await subject();
+
+          await blockchain.increaseTimeAsync(ONE_DAY_IN_SECONDS.add(10).toNumber());
 
           await ramp.connect(onRamper.wallet).signalIntent(depositId, usdc(50), receiver.address);
           const currentTimestamp = await blockchain.getCurrentTimestamp();

--- a/contracts/test/ramp.spec.ts
+++ b/contracts/test/ramp.spec.ts
@@ -906,6 +906,8 @@ describe("Ramp", () => {
         beforeEach(async () => {
           await subject();
 
+          await blockchain.increaseTimeAsync(ONE_DAY_IN_SECONDS.add(1).toNumber());
+
           await ramp.connect(onRamper.wallet).signalIntent(depositId, usdc(50), receiver.address);
           const currentTimestamp = await blockchain.getCurrentTimestamp();
           intentHash = calculateIntentHash(await calculateVenmoIdHash("2"), depositId, currentTimestamp);

--- a/contracts/utils/deploys.ts
+++ b/contracts/utils/deploys.ts
@@ -45,6 +45,7 @@ export default class DeployHelper {
     minDepositAmount: BigNumber,
     maxOnRampAmount: BigNumber,
     intentExpirationPeriod: BigNumber,
+    onRampCoolDownPeriod: BigNumber,
     sustainabilityFee: BigNumber,
     sustainabilityFeeRecipient: Address,
   ): Promise<Ramp> {
@@ -55,6 +56,7 @@ export default class DeployHelper {
       minDepositAmount,
       maxOnRampAmount,
       intentExpirationPeriod,
+      onRampCoolDownPeriod,
       sustainabilityFee,
       sustainabilityFeeRecipient
     );

--- a/contracts/utils/deploys.ts
+++ b/contracts/utils/deploys.ts
@@ -1,7 +1,6 @@
 import { BigNumber, Signer, ethers } from "ethers";
 
 import { Address } from "@utils/types";
-import { usdc } from "@utils/common";
 
 const circom = require("circomlibjs");
 
@@ -31,7 +30,6 @@ import {
 } from "../typechain/factories/contracts/processors";
 import { ManagedKeyHashAdapter__factory } from "../typechain/factories/contracts/processors/keyHashAdapters";
 import { NullifierRegistry__factory } from "../typechain/factories/contracts/processors/nullifierRegistries";
-import { ONE_DAY_IN_SECONDS } from "./constants";
 
 export default class DeployHelper {
   private _deployerSigner: Signer;
@@ -45,8 +43,10 @@ export default class DeployHelper {
     usdcToken: Address,
     poseidon: Address,
     minDepositAmount: BigNumber,
-    maxOnRampAmount: BigNumber = usdc(999),
-    intentExpirationPeriod: BigNumber = ONE_DAY_IN_SECONDS,
+    maxOnRampAmount: BigNumber,
+    intentExpirationPeriod: BigNumber,
+    sustainabilityFee: BigNumber,
+    sustainabilityFeeRecipient: Address,
   ): Promise<Ramp> {
     return await new Ramp__factory(this._deployerSigner).deploy(
       owner,
@@ -54,7 +54,9 @@ export default class DeployHelper {
       poseidon,
       minDepositAmount,
       maxOnRampAmount,
-      intentExpirationPeriod
+      intentExpirationPeriod,
+      sustainabilityFee,
+      sustainabilityFeeRecipient
     );
   }
 


### PR DESCRIPTION
@asoong main change I want to call out is that in the old version you passed in the venmoIdHash to get the `currentIntentHash` (to see if the user had one outstanding) but in this version you'd pass in their Ethereum address:

```
    function getVenmoIdCurrentIntentHash(address _account) external view returns (bytes32) {
        return globalAccount[accounts[_account].venmoIdHash].currentIntentHash;
    }
```

Previously you were calling this:
```
mapping(bytes32 => bytes32) public venmoIdIntent;           // Mapping of venmoIdHash to intentHash, we limit one intent per venmoId
```