### PR TITLE
Fix gen input acc num index

### DIFF
--- a/circuits-circom/package/generate_input.ts
+++ b/circuits-circom/package/generate_input.ts
@@ -539,8 +539,8 @@ export async function getCircuitInputs(
     const garanti_payee_name_selector = Buffer.from("\r\n\t\t\t\t\t<strong>");
     const garanti_payee_name_idx = (Buffer.from(bodyRemaining).indexOf(garanti_payee_name_selector) + garanti_payee_name_selector.length).toString();
 
-    const garanti_payee_acc_num_selector = Buffer.from("TR");
-    const garanti_payee_acc_num_idx = Buffer.from(bodyRemaining).indexOf(garanti_payee_acc_num_selector).toString();
+    const garanti_payee_acc_num_selector = Buffer.from("<br>TR");
+    const garanti_payee_acc_num_idx = (Buffer.from(bodyRemaining).indexOf(garanti_payee_acc_num_selector) + "<br>".length).toString();
 
     const garanti_amount_selector = Buffer.from("<p>Tutar: <strong>");
     const garanti_amount_idx = (Buffer.from(bodyRemaining).indexOf(garanti_amount_selector) + garanti_amount_selector.length).toString();


### PR DESCRIPTION
"TR" selector for acc num index doesn't work, because "TR" can appear anywhere before the target index in the email, for example in the  name or in the address. For example, "TR" below appears in "TREE"

```
 <strong>ULAŞ TEST<br>TREE / TEST -  345<br>9999999</strong></p>
<p>
Alıcı Bilgileri: <br>
<strong>Brian Michael Weickmann<br>TRXX XXXXXXXXXXXXXXXXXX</strong></p>
```
Fix: Updated selector to `<br>TR`