### PR TITLE
Remove onRamperId check when onramping since we already check call is…

### DIFF
--- a/contracts/contracts/ramps/wise/WiseAccountRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/WiseAccountRegistrationProcessor.sol
@@ -44,7 +44,7 @@ contract WiseAccountRegistrationProcessor is IWiseAccountRegistrationProcessor, 
 
     /* ============ External Functions ============ */
 
-    function processAccountProof(
+    function processProof(
         IWiseAccountRegistrationProcessor.RegistrationProof calldata _proof
     )
         public
@@ -57,7 +57,7 @@ contract WiseAccountRegistrationProcessor is IWiseAccountRegistrationProcessor, 
         _validateTLSEndpoint(endpoint, _proof.public_values.endpoint);
         _validateTLSHost(host, _proof.public_values.host);
 
-        _validateAndAddNullifier(keccak256(abi.encode("registration", _proof.public_values.profileId)));
+        _validateAndAddNullifier(keccak256(abi.encode(_proof.public_values.accessDate, _proof.public_values.profileId)));
 
         onRampId = bytes32(_proof.public_values.profileId.stringToUint(0));
         wiseTagHash = bytes32(_proof.public_values.wiseTagHash.stringToUint(0));
@@ -81,7 +81,13 @@ contract WiseAccountRegistrationProcessor is IWiseAccountRegistrationProcessor, 
         view
         returns(bool)
     {
-        bytes memory encodedMessage = abi.encode(_publicValues.endpoint, _publicValues.host, _publicValues.profileId, _publicValues.wiseTagHash);
+        bytes memory encodedMessage = abi.encode(
+            _publicValues.endpoint,
+            _publicValues.host,
+            _publicValues.profileId,
+            _publicValues.accessDate,
+            _publicValues.wiseTagHash
+        );
         return _isValidVerifierSignature(encodedMessage, _proof, verifierSigningKey);
     }
     

--- a/contracts/contracts/ramps/wise/WiseAccountRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/WiseAccountRegistrationProcessor.sol
@@ -57,7 +57,7 @@ contract WiseAccountRegistrationProcessor is IWiseAccountRegistrationProcessor, 
         _validateTLSEndpoint(endpoint, _proof.public_values.endpoint);
         _validateTLSHost(host, _proof.public_values.host);
 
-        _validateAndAddNullifier(keccak256(abi.encode(_proof.public_values.accessDate, _proof.public_values.profileId)));
+        _validateAndAddNullifier(keccak256(abi.encode(_proof.public_values.userAddress, _proof.public_values.profileId)));
 
         onRampId = bytes32(_proof.public_values.profileId.stringToUint(0));
         wiseTagHash = bytes32(_proof.public_values.wiseTagHash.stringToUint(0));
@@ -85,8 +85,8 @@ contract WiseAccountRegistrationProcessor is IWiseAccountRegistrationProcessor, 
             _publicValues.endpoint,
             _publicValues.host,
             _publicValues.profileId,
-            _publicValues.accessDate,
-            _publicValues.wiseTagHash
+            _publicValues.wiseTagHash,
+            _publicValues.userAddress
         );
         return _isValidVerifierSignature(encodedMessage, _proof, verifierSigningKey);
     }

--- a/contracts/contracts/ramps/wise/WiseAccountRegistry.sol
+++ b/contracts/contracts/ramps/wise/WiseAccountRegistry.sol
@@ -131,7 +131,6 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
             bytes32 offRampId
         ) = _verifyOffRamperRegistrationProof(_proof);
 
-        accounts[msg.sender].accountId = accountId;
         accounts[msg.sender].offRampId = offRampId;
 
         emit OffRamperRegistered(msg.sender, accountId, offRampId);
@@ -302,7 +301,7 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
         (
             accountId,
             wiseTagHash
-        ) = accountRegistrationProcessor.processAccountProof(_proof);
+        ) = accountRegistrationProcessor.processProof(_proof);
     }
 
     /**
@@ -318,8 +317,8 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
         (
             accountId,
             offRampId
-        ) = offRamperRegistrationProcessor.processOffRamperProof(_proof);
+        ) = offRamperRegistrationProcessor.processProof(_proof);
 
-        require(accountId == accounts[msg.sender].accountId, "OnRampId does not match");
+        require(accountId == accounts[msg.sender].accountId, "AccountId does not match");
     }
 }

--- a/contracts/contracts/ramps/wise/WiseAccountRegistry.sol
+++ b/contracts/contracts/ramps/wise/WiseAccountRegistry.sol
@@ -101,6 +101,7 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
     )
         external
     {
+        require(msg.sender == _proof.public_values.userAddress, "Caller must be address specified in proof");
         require(accounts[msg.sender].accountId == bytes32(0), "Account already associated with accountId");
         (
             bytes32 accountId,

--- a/contracts/contracts/ramps/wise/WiseOffRamperRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/WiseOffRamperRegistrationProcessor.sol
@@ -39,7 +39,7 @@ contract WiseOffRamperRegistrationProcessor is IWiseOffRamperRegistrationProcess
 
     /* ============ External Functions ============ */
 
-    function processOffRamperProof(
+    function processProof(
         IWiseOffRamperRegistrationProcessor.OffRamperRegistrationProof calldata _proof
     )
         public
@@ -51,8 +51,6 @@ contract WiseOffRamperRegistrationProcessor is IWiseOffRamperRegistrationProcess
 
         _validateTLSEndpoint(endpoint.replaceString("*", _proof.public_values.profileId), _proof.public_values.endpoint);
         _validateTLSHost(host, _proof.public_values.host);
-
-        _validateAndAddNullifier(keccak256(abi.encode("registration", _proof.public_values.mcAccountId)));
 
         onRampId = bytes32(_proof.public_values.profileId.stringToUint(0));
         offRampId = bytes32(_proof.public_values.mcAccountId.stringToUint(0));

--- a/contracts/contracts/ramps/wise/WiseOffRamperRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/WiseOffRamperRegistrationProcessor.sol
@@ -43,6 +43,7 @@ contract WiseOffRamperRegistrationProcessor is IWiseOffRamperRegistrationProcess
         IWiseOffRamperRegistrationProcessor.OffRamperRegistrationProof calldata _proof
     )
         public
+        view
         override
         onlyRamp
         returns(bytes32 onRampId, bytes32 offRampId)

--- a/contracts/contracts/ramps/wise/WiseRamp.sol
+++ b/contracts/contracts/ramps/wise/WiseRamp.sol
@@ -680,7 +680,7 @@ contract WiseRamp is Ownable {
             uint256 amount,
             uint256 timestamp,
             bytes32 offRamperId,
-            bytes32 onRamperId,
+            ,
             bytes32 currencyId
         ) = sendProcessor.processProof(
             IWiseSendProcessor.SendProof({
@@ -693,7 +693,6 @@ contract WiseRamp is Ownable {
         require(currencyId == deposit.receiveCurrencyId, "Wrong currency sent");
         require(intent.intentTimestamp <= timestamp, "Intent was not created before send");
         require(accountRegistry.getAccountInfo(deposit.depositor).offRampId == offRamperId, "Offramper id does not match");
-        require(accountRegistry.getAccountId(intent.onRamper) == onRamperId, "Onramper id does not match");
         require(amount >= (intent.amount * PRECISE_UNIT) / deposit.conversionRate, "Payment was not enough");
     }
 }

--- a/contracts/contracts/ramps/wise/WiseRamp.sol
+++ b/contracts/contracts/ramps/wise/WiseRamp.sol
@@ -680,7 +680,6 @@ contract WiseRamp is Ownable {
             uint256 amount,
             uint256 timestamp,
             bytes32 offRamperId,
-            ,
             bytes32 currencyId
         ) = sendProcessor.processProof(
             IWiseSendProcessor.SendProof({

--- a/contracts/contracts/ramps/wise/WiseSendProcessor.sol
+++ b/contracts/contracts/ramps/wise/WiseSendProcessor.sol
@@ -49,7 +49,6 @@ contract WiseSendProcessor is IWiseSendProcessor, TLSBaseProcessor {
             uint256 amount,
             uint256 timestamp,
             bytes32 offRamperId,
-            bytes32 onRamperId,
             bytes32 currencyId
         )
     {
@@ -74,7 +73,6 @@ contract WiseSendProcessor is IWiseSendProcessor, TLSBaseProcessor {
         timestamp = _proof.public_values.timestamp.stringToUint(0) / 1000 + timestampBuffer;
 
         offRamperId = bytes32(_proof.public_values.recipientId.stringToUint(0));
-        onRamperId = bytes32(_proof.public_values.senderId.stringToUint(0));
         currencyId = keccak256(abi.encodePacked(_proof.public_values.currencyId));
     }
 

--- a/contracts/contracts/ramps/wise/interfaces/IWiseAccountRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/interfaces/IWiseAccountRegistrationProcessor.sol
@@ -8,8 +8,8 @@ interface IWiseAccountRegistrationProcessor {
         string endpoint;
         string host;
         string profileId;
-        string accessDate;
         string wiseTagHash;
+        address userAddress;
     }
 
     struct RegistrationProof {

--- a/contracts/contracts/ramps/wise/interfaces/IWiseAccountRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/interfaces/IWiseAccountRegistrationProcessor.sol
@@ -8,6 +8,7 @@ interface IWiseAccountRegistrationProcessor {
         string endpoint;
         string host;
         string profileId;
+        string accessDate;
         string wiseTagHash;
     }
 
@@ -16,7 +17,7 @@ interface IWiseAccountRegistrationProcessor {
         bytes proof;
     }
 
-    function processAccountProof(
+    function processProof(
         RegistrationProof calldata _proof
     )
         external

--- a/contracts/contracts/ramps/wise/interfaces/IWiseOffRamperRegistrationProcessor.sol
+++ b/contracts/contracts/ramps/wise/interfaces/IWiseOffRamperRegistrationProcessor.sol
@@ -16,7 +16,7 @@ interface IWiseOffRamperRegistrationProcessor {
         bytes proof;
     }
 
-    function processOffRamperProof(
+    function processProof(
         OffRamperRegistrationProof calldata _proof
     )
         external

--- a/contracts/contracts/ramps/wise/interfaces/IWiseSendProcessor.sol
+++ b/contracts/contracts/ramps/wise/interfaces/IWiseSendProcessor.sol
@@ -27,5 +27,5 @@ interface IWiseSendProcessor {
         address _verifierSigningKey
     )
         external
-    returns(uint256, uint256, bytes32, bytes32, bytes32);
+    returns(uint256, uint256, bytes32, bytes32);
 }

--- a/contracts/contracts/ramps/wise/mocks/WiseAccountRegistrationProcessorMock.sol
+++ b/contracts/contracts/ramps/wise/mocks/WiseAccountRegistrationProcessorMock.sol
@@ -13,7 +13,7 @@ contract WiseAccountRegistrationProcessorMock is IWiseAccountRegistrationProcess
     constructor() {}
 
     /* ============ External View Functions ============ */
-    function processAccountProof(
+    function processProof(
         RegistrationProof calldata _proof
     )
         public

--- a/contracts/contracts/ramps/wise/mocks/WiseOffRamperRegistrationProcessorMock.sol
+++ b/contracts/contracts/ramps/wise/mocks/WiseOffRamperRegistrationProcessorMock.sol
@@ -13,7 +13,7 @@ contract WiseOffRamperRegistrationProcessorMock is IWiseOffRamperRegistrationPro
     constructor() {}
 
     /* ============ External View Functions ============ */
-    function processOffRamperProof(
+    function processProof(
        OffRamperRegistrationProof calldata _proof
     )
         public

--- a/contracts/contracts/ramps/wise/mocks/WiseSendProcessorMock.sol
+++ b/contracts/contracts/ramps/wise/mocks/WiseSendProcessorMock.sol
@@ -24,7 +24,6 @@ contract WiseSendProcessorMock is IWiseSendProcessor {
             uint256 amount,
             uint256 timestamp,
             bytes32 offRamperIdHash,
-            bytes32 onRamperIdHash,
             bytes32 currencyId
         )
     {
@@ -32,7 +31,6 @@ contract WiseSendProcessorMock is IWiseSendProcessor {
             _proof.public_values.amount.stringToUint(6),
             _proof.public_values.timestamp.stringToUint(0),
             bytes32(_proof.public_values.recipientId.stringToUint(0)),
-            bytes32(_proof.public_values.senderId.stringToUint(0)),
             keccak256(abi.encodePacked(_proof.public_values.currencyId))
         );
     }

--- a/contracts/test/ramps/wise/wiseAccountRegistrationProcessor.spec.ts
+++ b/contracts/test/ramps/wise/wiseAccountRegistrationProcessor.spec.ts
@@ -11,13 +11,13 @@ import {
   getWaffleExpect,
   getAccounts
 } from "@utils/test/index";
-import { Address, WiseRegistrationProof } from "@utils/types";
+import { Address, WiseRegistrationData, WiseRegistrationProof } from "@utils/types";
 import { calculateWiseId, calculateWiseTagHash } from "@utils/protocolUtils";
 
 const expect = getWaffleExpect();
 const abiCoder = new ethers.utils.AbiCoder();
 
-describe("WiseAccountRegistrationProcessor", () => {
+describe.only("WiseAccountRegistrationProcessor", () => {
   let owner: Account;
   let verifier: Account;
   let attacker: Account;
@@ -68,7 +68,7 @@ describe("WiseAccountRegistrationProcessor", () => {
     });
   });
 
-  describe("#processAccountProof", async () => {
+  describe.only("#processProof", async () => {
     let subjectProof: WiseRegistrationProof;
     let subjectCaller: Account;
 
@@ -78,20 +78,21 @@ describe("WiseAccountRegistrationProcessor", () => {
           endpoint: "POST https://wise.com/gateway/v1/payments",
           host: "wise.com",
           profileId: "41213881",
+          accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
           wiseTagHash: "61158579531006309039872672420732308054473459091416465738091051601559791768344"
-        },
-        proof: "0xba03085b486a2f7bab46cef658ea930b2be69368a3f1d547d0afc99ef382cda0384e6e80a15a832c7416dc5882e9b5e05c16c6f33885a4c5794f1e1a058605831b"
+        } as WiseRegistrationData,
+        proof: "0xca9598ff3b780c6c644075070d2faac7393d07f3ac3708e1eb5fd60bbb1e4c955661a0f8e440c0334615809559465d1279017a0aef68e599b9d32830ae6021921c"
       } as WiseRegistrationProof;
 
       subjectCaller = ramp;
     });
 
     async function subject(): Promise<any> {
-      return await registrationProcessor.connect(subjectCaller.wallet).processAccountProof(subjectProof);
+      return await registrationProcessor.connect(subjectCaller.wallet).processProof(subjectProof);
     }
 
     async function subjectCallStatic(): Promise<any> {
-      return await registrationProcessor.connect(subjectCaller.wallet).callStatic.processAccountProof(subjectProof);
+      return await registrationProcessor.connect(subjectCaller.wallet).callStatic.processProof(subjectProof);
     }
 
     it("should process the proof", async () => {
@@ -107,7 +108,7 @@ describe("WiseAccountRegistrationProcessor", () => {
       const expectedNullifier = ethers.utils.keccak256(
         abiCoder.encode(
           ["string", "string"],
-          ["registration", subjectProof.public_values.profileId]
+          [subjectProof.public_values.accessDate, subjectProof.public_values.profileId]
         )
       );
 
@@ -141,11 +142,12 @@ describe("WiseAccountRegistrationProcessor", () => {
         subjectProof.public_values.endpoint = "GET https://wise.com/gateway/v4/profiles/41213881";
 
         const encodedMsg = abiCoder.encode(
-          ["string", "string", "string", "string"],
+          ["string", "string", "string", "string", "string"],
           [
             subjectProof.public_values.endpoint,
             subjectProof.public_values.host,
             subjectProof.public_values.profileId,
+            subjectProof.public_values.accessDate,
             subjectProof.public_values.wiseTagHash
           ]
         );
@@ -163,11 +165,12 @@ describe("WiseAccountRegistrationProcessor", () => {
         subjectProof.public_values.host = "api.wise.com";
 
         const encodedMsg = abiCoder.encode(
-          ["string", "string", "string", "string"],
+          ["string", "string", "string", "string", "string"],
           [
             subjectProof.public_values.endpoint,
             subjectProof.public_values.host,
             subjectProof.public_values.profileId,
+            subjectProof.public_values.accessDate,
             subjectProof.public_values.wiseTagHash
           ]
         );

--- a/contracts/test/ramps/wise/wiseAccountRegistrationProcessor.spec.ts
+++ b/contracts/test/ramps/wise/wiseAccountRegistrationProcessor.spec.ts
@@ -17,7 +17,7 @@ import { calculateWiseId, calculateWiseTagHash } from "@utils/protocolUtils";
 const expect = getWaffleExpect();
 const abiCoder = new ethers.utils.AbiCoder();
 
-describe.only("WiseAccountRegistrationProcessor", () => {
+describe("WiseAccountRegistrationProcessor", () => {
   let owner: Account;
   let verifier: Account;
   let attacker: Account;
@@ -68,7 +68,7 @@ describe.only("WiseAccountRegistrationProcessor", () => {
     });
   });
 
-  describe.only("#processProof", async () => {
+  describe("#processProof", async () => {
     let subjectProof: WiseRegistrationProof;
     let subjectCaller: Account;
 
@@ -78,10 +78,10 @@ describe.only("WiseAccountRegistrationProcessor", () => {
           endpoint: "POST https://wise.com/gateway/v1/payments",
           host: "wise.com",
           profileId: "41213881",
-          accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
-          wiseTagHash: "61158579531006309039872672420732308054473459091416465738091051601559791768344"
+          wiseTagHash: "61158579531006309039872672420732308054473459091416465738091051601559791768344",
+          userAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
         } as WiseRegistrationData,
-        proof: "0xca9598ff3b780c6c644075070d2faac7393d07f3ac3708e1eb5fd60bbb1e4c955661a0f8e440c0334615809559465d1279017a0aef68e599b9d32830ae6021921c"
+        proof: "0xe8d9937381ea1a4e4079d1007edc3d63fbeeb62b5759c9259f1c11b671ef8b7014fb621bea79abfe22aa3d29a77d2601adb25b55890c2f3e1f9f436870d549b61b"
       } as WiseRegistrationProof;
 
       subjectCaller = ramp;
@@ -107,8 +107,8 @@ describe.only("WiseAccountRegistrationProcessor", () => {
 
       const expectedNullifier = ethers.utils.keccak256(
         abiCoder.encode(
-          ["string", "string"],
-          [subjectProof.public_values.accessDate, subjectProof.public_values.profileId]
+          ["address", "string"],
+          [subjectProof.public_values.userAddress, subjectProof.public_values.profileId]
         )
       );
 
@@ -142,13 +142,13 @@ describe.only("WiseAccountRegistrationProcessor", () => {
         subjectProof.public_values.endpoint = "GET https://wise.com/gateway/v4/profiles/41213881";
 
         const encodedMsg = abiCoder.encode(
-          ["string", "string", "string", "string", "string"],
+          ["string", "string", "string", "string", "address"],
           [
             subjectProof.public_values.endpoint,
             subjectProof.public_values.host,
             subjectProof.public_values.profileId,
-            subjectProof.public_values.accessDate,
-            subjectProof.public_values.wiseTagHash
+            subjectProof.public_values.wiseTagHash,
+            subjectProof.public_values.userAddress
           ]
         );
 
@@ -165,13 +165,13 @@ describe.only("WiseAccountRegistrationProcessor", () => {
         subjectProof.public_values.host = "api.wise.com";
 
         const encodedMsg = abiCoder.encode(
-          ["string", "string", "string", "string", "string"],
+          ["string", "string", "string", "string", "address"],
           [
             subjectProof.public_values.endpoint,
             subjectProof.public_values.host,
             subjectProof.public_values.profileId,
-            subjectProof.public_values.accessDate,
-            subjectProof.public_values.wiseTagHash
+            subjectProof.public_values.wiseTagHash,
+            subjectProof.public_values.userAddress
           ]
         );
 

--- a/contracts/test/ramps/wise/wiseAccountRegistry.spec.ts
+++ b/contracts/test/ramps/wise/wiseAccountRegistry.spec.ts
@@ -29,6 +29,7 @@ const expect = getWaffleExpect();
 describe("WiseAccountRegistry", () => {
   let owner: Account;
   let offRamper: Account;
+  let onRamper: Account;
   let unregisteredUser: Account;
 
   let accountRegistry: WiseAccountRegistry;
@@ -42,6 +43,7 @@ describe("WiseAccountRegistry", () => {
     [
       owner,
       offRamper,
+      onRamper,
       unregisteredUser,
     ] = await getAccounts();
 
@@ -128,7 +130,8 @@ describe("WiseAccountRegistry", () => {
         endpoint: "GET https://api.transferwise.com/v4/profiles/41246868/multi-currency-account",
         host: "api.transferwise.com",
         profileId: "405394441",
-        wiseTagHash: calculateWiseTagHash("jdoe1234")
+        wiseTagHash: calculateWiseTagHash("jdoe1234"),
+        userAddress: offRamper.address
       } as WiseRegistrationData
 
       subjectProof = {
@@ -159,6 +162,16 @@ describe("WiseAccountRegistry", () => {
       );
     });
 
+    describe("when the caller is not the address signed by verifier", async () => {
+      beforeEach(async () => {
+        subjectProof.public_values.userAddress = onRamper.address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Caller must be address specified in proof");
+      });
+    });
+
     describe("when the caller is already registered", async () => {
       beforeEach(async () => {
         await subject();
@@ -186,14 +199,16 @@ describe("WiseAccountRegistry", () => {
         endpoint: "GET https://api.transferwise.com/v4/profiles/41246868/multi-currency-account",
         host: "api.transferwise.com",
         profileId: "",
-        accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
-        wiseTagHash: ""
+        wiseTagHash: "",
+        userAddress: ""
       }
       offRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       offRamperProof.public_values.profileId = "012345678";
       offRamperProof.public_values.wiseTagHash = calculateWiseTagHash("jdoe1234");
+      offRamperProof.public_values.userAddress = offRamper.address;
       onRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       onRamperProof.public_values.profileId = "123456789";
+      onRamperProof.public_values.userAddress = onRamper.address;
 
       await accountRegistry.connect(offRamper.wallet).register(offRamperProof);
     });

--- a/contracts/test/ramps/wise/wiseAccountRegistry.spec.ts
+++ b/contracts/test/ramps/wise/wiseAccountRegistry.spec.ts
@@ -186,6 +186,7 @@ describe("WiseAccountRegistry", () => {
         endpoint: "GET https://api.transferwise.com/v4/profiles/41246868/multi-currency-account",
         host: "api.transferwise.com",
         profileId: "",
+        accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
         wiseTagHash: ""
       }
       offRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
@@ -252,7 +253,7 @@ describe("WiseAccountRegistry", () => {
         });
   
         it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("OnRampId does not match");
+          await expect(subject()).to.be.revertedWith("AccountId does not match");
         });
       });
   

--- a/contracts/test/ramps/wise/wiseOffRamperRegistrationProcessor.spec.ts
+++ b/contracts/test/ramps/wise/wiseOffRamperRegistrationProcessor.spec.ts
@@ -68,7 +68,7 @@ describe("WiseOffRamperRegistrationProcessor", () => {
     });
   });
 
-  describe("#processOffRamperProof", async () => {
+  describe.only("#processProof", async () => {
     let subjectProof: WiseOffRamperRegistrationProof;
     let subjectCaller: Account;
 
@@ -88,11 +88,11 @@ describe("WiseOffRamperRegistrationProcessor", () => {
     });
 
     async function subject(): Promise<any> {
-      return await registrationProcessor.connect(subjectCaller.wallet).processOffRamperProof(subjectProof);
+      return await registrationProcessor.connect(subjectCaller.wallet).processProof(subjectProof);
     }
 
     async function subjectCallStatic(): Promise<any> {
-      return await registrationProcessor.connect(subjectCaller.wallet).callStatic.processOffRamperProof(subjectProof);
+      return await registrationProcessor.connect(subjectCaller.wallet).callStatic.processProof(subjectProof);
     }
 
     it("should process the proof", async () => {
@@ -100,31 +100,6 @@ describe("WiseOffRamperRegistrationProcessor", () => {
       
       expect(onRamperId).to.eq(calculateWiseId(subjectProof.public_values.profileId));
       expect(offRamperId).to.eq(calculateWiseId(subjectProof.public_values.mcAccountId));
-    });
-
-    it("should add the hash of the proof inputs to the nullifier registry", async () => {
-      await subject();
-
-      const expectedNullifier = ethers.utils.keccak256(
-        abiCoder.encode(
-          ["string", "string"],
-          ["registration", subjectProof.public_values.mcAccountId]
-        )
-      );
-
-      const isNullified = await nullifierRegistry.isNullified(expectedNullifier);
-
-      expect(isNullified).to.be.true;
-    });
-
-    describe("when the profile has already been verified", async () => {
-      beforeEach(async () => {
-        await subject();
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Nullifier has already been used");
-      });
     });
 
     describe("when the proof is invalid", async () => {

--- a/contracts/test/ramps/wise/wiseOffRamperRegistrationProcessor.spec.ts
+++ b/contracts/test/ramps/wise/wiseOffRamperRegistrationProcessor.spec.ts
@@ -68,7 +68,7 @@ describe("WiseOffRamperRegistrationProcessor", () => {
     });
   });
 
-  describe.only("#processProof", async () => {
+  describe("#processProof", async () => {
     let subjectProof: WiseOffRamperRegistrationProof;
     let subjectCaller: Account;
 

--- a/contracts/test/ramps/wise/wiseRamp.spec.ts
+++ b/contracts/test/ramps/wise/wiseRamp.spec.ts
@@ -189,19 +189,23 @@ describe("WiseRamp", () => {
         endpoint: "GET https://api.transferwise.com/v4/profiles/41246868/multi-currency-account",
         host: "api.transferwise.com",
         profileId: "",
-        accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
-        wiseTagHash: ""
+        wiseTagHash: "",
+        userAddress: ""
       }
 
       offRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       offRamperProof.public_values.profileId = "012345678";
       offRamperProof.public_values.wiseTagHash = calculateWiseTagHash("jdoe1234");
+      offRamperProof.public_values.userAddress = offRamper.address;
       onRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       onRamperProof.public_values.profileId = "123456789";
+      onRamperProof.public_values.userAddress = onRamper.address;
       onRamperTwoProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       onRamperTwoProof.public_values.profileId = "567890123";
+      onRamperTwoProof.public_values.userAddress = onRamperTwo.address;
       maliciousOnRamperProof = { public_values: {...standardRegistrationData}, proof: "0x"};
       maliciousOnRamperProof.public_values.profileId = "123456789";
+      maliciousOnRamperProof.public_values.userAddress = maliciousOnRamper.address;
 
       await accountRegistry.connect(offRamper.wallet).register(offRamperProof);
       await accountRegistry.connect(onRamper.wallet).register(onRamperProof);
@@ -562,6 +566,7 @@ describe("WiseRamp", () => {
 
       describe("when the caller is the depositor from another Ethereum account", async () => {
         beforeEach(async () => {
+          offRamperProof.public_values.userAddress = offRamperNewAcct.address;
           await accountRegistry.connect(offRamperNewAcct.wallet).register(offRamperProof);
 
           subjectCaller = offRamperNewAcct;
@@ -746,6 +751,7 @@ describe("WiseRamp", () => {
 
       describe("when the call comes from a different Eth address tied to the same venmoIdHash", async () => {
         beforeEach(async () => {
+          onRamperProof.public_values.userAddress = onRamperOtherAddress.address;
           await accountRegistry.connect(onRamperOtherAddress.wallet).register(onRamperProof);
 
           subjectCaller = onRamperOtherAddress;

--- a/contracts/test/ramps/wise/wiseRamp.spec.ts
+++ b/contracts/test/ramps/wise/wiseRamp.spec.ts
@@ -189,6 +189,7 @@ describe("WiseRamp", () => {
         endpoint: "GET https://api.transferwise.com/v4/profiles/41246868/multi-currency-account",
         host: "api.transferwise.com",
         profileId: "",
+        accessDate: "Fri, 01 Mar 2024 02:57:30 GMT",
         wiseTagHash: ""
       }
 
@@ -1032,16 +1033,6 @@ describe("WiseRamp", () => {
 
         it("should revert", async () => {
           await expect(subject()).to.be.revertedWith("Offramper id does not match");
-        });
-      });
-
-      describe("when the onRamperId doesn't match the intent", async () => {
-        beforeEach(async () => {
-          subjectSendData.senderId = calculateWiseId(onRamperTwoProof.public_values.profileId);
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("Onramper id does not match");
         });
       });
     });

--- a/contracts/test/ramps/wise/wiseSendProcessor.spec.ts
+++ b/contracts/test/ramps/wise/wiseSendProcessor.spec.ts
@@ -101,13 +101,11 @@ describe("WiseSendProcessor", () => {
         amount,
         timestamp,
         offRamperId,
-        onRamperId,
         currencyId
       ] = await subjectCallStatic();
       
       expect(amount).to.eq(usdc(1));
       expect(timestamp).to.eq(BigNumber.from(subjectProof.public_values.timestamp).div(1000).add(30));
-      expect(onRamperId).to.eq(calculateWiseId(subjectProof.public_values.senderId));
       expect(offRamperId).to.eq(calculateWiseId(subjectProof.public_values.recipientId));
       expect(currencyId).to.eq(ethers.utils.solidityKeccak256(["string"], [subjectProof.public_values.currencyId]));
     });

--- a/contracts/utils/types.ts
+++ b/contracts/utils/types.ts
@@ -26,6 +26,7 @@ export interface WiseRegistrationData {
   endpoint: string;
   host: string;
   profileId: string;
+  accessDate: string;
   wiseTagHash: string;
 }
 

--- a/contracts/utils/types.ts
+++ b/contracts/utils/types.ts
@@ -26,8 +26,8 @@ export interface WiseRegistrationData {
   endpoint: string;
   host: string;
   profileId: string;
-  accessDate: string;
   wiseTagHash: string;
+  userAddress: Address;
 }
 
 export interface WiseRegistrationProof {


### PR DESCRIPTION
CHANGELOG:
- Remove onRamperId check when onramping since we already check call is coming from onRamper's address
- Add timestamp to account registration for nullification
- Remove nullifier on offRamperRegistration since not necessary - we already check to make sure that the `accountId` matches in the proof so it couldn't be used by another person to create an offRamper registration (unless they had access to the user's account to create an account registration since those proofs are nullified). Also cannot be reused for any other proofs
- Make sure all processors just have processProof as function sig for proof processing