### PR TITLE
Toggle Notarization Table Icon by Circuit

### DIFF
--- a/client/src/contexts/common/NotarySettings/NotarySettingsProvider.tsx
+++ b/client/src/contexts/common/NotarySettings/NotarySettingsProvider.tsx
@@ -13,6 +13,8 @@ import useGithubClient from '@hooks/useFetchNotaryList';
 import NotarySettingsContext from './NotarySettingsContext';
 
 
+export const UPLOAD_TIME_THRESHOLD = 5;
+
 interface ProvidersProps {
   children: ReactNode;
 };
@@ -82,7 +84,7 @@ const NotarySettingsProvider = ({ children }: ProvidersProps) => {
 
   useEffect(() => {
     if (uploadTime) {
-      if (uploadTime < 3) {
+      if (uploadTime < UPLOAD_TIME_THRESHOLD) {
         setConnectionStatus(NotaryConnectionStatus.GREEN);
       } else {
         setConnectionStatus(NotaryConnectionStatus.RED);

--- a/client/src/hooks/useRemoteNotaryUploadTest.ts
+++ b/client/src/hooks/useRemoteNotaryUploadTest.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 
-export const UPLOAD_TIME_THRESHOLD = 3;
 const UPLOAD_SIZE_BYTES = 4.9 * 1024 * 1024;
 
 type UploadParams = {


### PR DESCRIPTION
Registration:
<img width="635" alt="Screenshot 2024-05-08 at 1 12 46 PM" src="https://github.com/zkp2p/zk-p2p/assets/3453571/07e0cba9-cd3a-464f-89c8-edb3d1f2ca30">

<img width="638" alt="Screenshot 2024-05-08 at 1 16 21 PM" src="https://github.com/zkp2p/zk-p2p/assets/3453571/ebd6808f-ffb9-41a6-be91-b697fea2a0ba">


On-ramp:
* Can't make it past verification rn, can review the source but icons will be CheckCircle and Slash for on-ramp