### PR TITLE
Fix typos

### DIFF
--- a/contracts-ramp/contracts/ramps/revolut/RevolutAccountRegistry.sol
+++ b/contracts-ramp/contracts/ramps/revolut/RevolutAccountRegistry.sol
@@ -172,7 +172,7 @@ contract RevolutAccountRegistry is IRevolutAccountRegistry, Ownable {
     }
 
     /**
-     * @notice Removes an passed accountId's from allow list. If allow list is enabled only users on the allow list will be
+     * @notice Removes a passed accountId's from allow list. If allow list is enabled only users on the allow list will be
      * able to signal intents on the user's deposit.
      *
      * @param _disallowedUsers   List of accountIds being approved

--- a/contracts-ramp/contracts/ramps/revolut/RevolutAccountRegistry.sol
+++ b/contracts-ramp/contracts/ramps/revolut/RevolutAccountRegistry.sol
@@ -243,7 +243,7 @@ contract RevolutAccountRegistry is IRevolutAccountRegistry, Ownable {
     /* ============ Internal Functions ============ */
 
     /**
-     * @notice Validate the user has an Revolut account. We nullify this accountId along with the calling address so that
+     * @notice Validate the user has a Revolut account. We nullify this accountId along with the calling address so that
      * it can't be used again.
      */
     function _verifyRegistrationProof(

--- a/contracts-ramp/contracts/ramps/wise/WiseAccountRegistry.sol
+++ b/contracts-ramp/contracts/ramps/wise/WiseAccountRegistry.sol
@@ -205,7 +205,7 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
     }
 
     /**
-     * @notice Removes an passed accountId's from allow list. If allow list is enabled only users on the allow list will be
+     * @notice Removes a passed accountId's from allow list. If allow list is enabled only users on the allow list will be
      * able to signal intents on the user's deposit.
      *
      * @param _disallowedUsers   List of accountIds being approved
@@ -290,7 +290,7 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
     /* ============ Internal Functions ============ */
 
     /**
-     * @notice Validate the user has an Wise account, we do not nullify this email since it can be reused to register under
+     * @notice Validate the user has a Wise account, we do not nullify this email since it can be reused to register under
      * different addresses.
      */
     function _verifyRegistrationProof(
@@ -306,7 +306,7 @@ contract WiseAccountRegistry is IWiseAccountRegistry, Ownable {
     }
 
     /**
-     * @notice Validate the user has an Wise account, we do not nullify this email since it can be reused to register under
+     * @notice Validate the user has a Wise account, we do not nullify this email since it can be reused to register under
      * different addresses.
      */
     function _verifyOffRamperRegistrationProof(


### PR DESCRIPTION
This pull request corrects grammatical errors in comments across two smart contracts: `RevolutAccountRegistry.sol` and `WiseAccountRegistry.sol`. 
The changes replace incorrect usage of "an" with "a" when referring to words that do not begin with a vowel sound, improving the readability and accuracy of the documentation.

### Files Updated

1. **RevolutAccountRegistry.sol**
   - Corrected: `"an passed accountId's"` → `"a passed accountId's"`
   - Corrected: `"an Revolut account"` → `"a Revolut account"`

2. **WiseAccountRegistry.sol**
   - Corrected: `"an passed accountId's"` → `"a passed accountId's"`
   - Corrected: `"an Wise account"` → `"a Wise account"`
