### PR TITLE
Fix Potential Overflow Problem within `NamecheapPushDomainVerifier`

### DIFF
--- a/circuits-circom/circuits/namecheap/namecheap_push.circom
+++ b/circuits-circom/circuits/namecheap/namecheap_push.circom
@@ -1,5 +1,6 @@
 pragma circom 2.1.9;
 
+include "../node_modules/circomlib/circuits/bitify.circom";
 include "circomlib/circuits/poseidon.circom";
 include "@zk-email/circuits/utils/regex.circom";
 include "@zk-email/circuits/helpers/email-nullifier.circom";
@@ -97,6 +98,10 @@ template NamecheapPushDomainVerifier(maxHeadersLength, maxBodyLength, n, k) {
     // Output packed email from
     signal input fromEmailIndex;
     
+    // Assert the bit-length of fromEmailIndex
+    component fromEmailIndexBits = Num2Bits(log2Ceil(maxHeadersLength));
+    fromEmailIndexBits.in <== fromEmailIndex;
+
     // Assert fromEmailIndex < emailHeaderLength
     signal isFromIndexValid <== LessThan(log2Ceil(maxHeadersLength))([fromEmailIndex, emailHeaderLength]);
     isFromIndexValid === 1;

--- a/circuits-circom/circuits/namecheap/namecheap_push.circom
+++ b/circuits-circom/circuits/namecheap/namecheap_push.circom
@@ -110,6 +110,10 @@ template NamecheapPushDomainVerifier(maxHeadersLength, maxBodyLength, n, k) {
 
     // Packed buyer id (Hashed before making public output)
     signal input namecheapBuyerIdIndex;
+
+    // Assert the bit-length of namecheapBuyerIdIndex
+    component namecheapBuyerIdIndexBits = Num2Bits(log2Ceil(maxBodyLength));
+    namecheapBuyerIdIndexBits.in <== namecheapBuyerIdIndex;
     
     // Assert namecheapBuyerIdIndex < emailBodyLength
     signal namecheapBuyerIdIndexValid <== LessThan(log2Ceil(maxBodyLength))([namecheapBuyerIdIndex, emailBodyLength]);
@@ -119,6 +123,10 @@ template NamecheapPushDomainVerifier(maxHeadersLength, maxBodyLength, n, k) {
 
     // Output packed domain name
     signal input namecheapDomainNameIndex;
+
+    // Assert the bit-length of namecheapDomainNameIndex
+    component namecheapDomainNameIndexBits = Num2Bits(log2Ceil(maxBodyLength));
+    namecheapDomainNameIndexBits.in <== namecheapDomainNameIndex;
     
     // Assert namecheapDomainNameIndex < emailBodyLength
     signal namecheapDomainNameIndexValid <== LessThan(log2Ceil(maxBodyLength))([namecheapDomainNameIndex, emailBodyLength]);


### PR DESCRIPTION
## Overview

`NamecheapPushDomainVerifier` template currently validates `fromEmailIndex < emailHeaderLength`, `namecheapBuyerIdIndex < emailBodyLength`, and `namecheapDomainNameIndex < emailBodyLength` with `LessThan` template.

However, the `LessThan(N)` template has a known over-flow issue: If the bit-length of the input exceeds $N$, `LessThan` may produce unintended results. For example, suppose `maxHeadersLength = 768`, `emailHeaderLength = 512`, and `fromEmailIndex = 21888242871839275222246405745257275088548364400416034343698204186575808495588`. In this case, the output of `LessThan(log2Ceil(maxHeadersLength))([fromEmailIndex, emailHeaderLength])` is `1`, meaning that this malicious input satisfies the constraints of `NamecheapPushDomainVerifier`. 

## Fix

To address this problem, I implemented a check on the bit-length of inputs with `Num2Bits` from `circomlib`.

## Reference

For more details on this vulnerability, refer to:
- https://github.com/BlakeMScurr/comparator-overflow
- https://github.com/zkemail/zk-regex/pull/83

## Note

[`FromRegex`](https://github.com/zkp2p/zk-p2p/blob/91c54d61c9f0aad71fcb9537c544f6fe7bbb94ab/circuits-circom/circuits/common/regexes/from_regex.circom#L6C10-L6C19), [`BodyHashRegex`](https://github.com/zkp2p/zk-p2p/blob/91c54d61c9f0aad71fcb9537c544f6fe7bbb94ab/circuits-circom/circuits/common/regexes/body_hash_regex.circom#L6), and [`VenmoTimestampRegex`](https://github.com/zkp2p/zk-p2p/blob/91c54d61c9f0aad71fcb9537c544f6fe7bbb94ab/circuits-circom/circuits/venmo/regexes/venmo_timestamp.circom#L31) also contains `LessThan` without bit-length check. However, this seems fine since they are used for utf-8 body.