### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-domain.yml
+++ b/.github/workflows/contracts-domain.yml
@@ -7,7 +7,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-ramp.yml
+++ b/.github/workflows/contracts-ramp.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected