### PR TITLE
Added missing range checks at call sites of Sha256BytesPartial

### DIFF
--- a/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
+++ b/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
@@ -4,6 +4,7 @@ include "@zk-email/circuits/helpers/sha.circom";
 include "@zk-email/circuits/helpers/extract.circom";
 
 include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
+include "@zk-email/circuits/utils/functions.circom"; // needed for log2Ceil
 
 template BodySuffixHasher(max_body_suffix_bytes) {
     assert(max_body_suffix_bytes % 64 == 0);
@@ -23,7 +24,7 @@ template BodySuffixHasher(max_body_suffix_bytes) {
     // This check is crucial for the soundness of Sha256BytesPartial.
     // For details, see:
     // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44  
-    var suffixLenBits = ceil_log2(max_body_suffix_bytes * 8);
+    var suffixLenBits = log2Ceil(max_body_suffix_bytes * 8);
     component suffixLenCheck = Num2Bits(suffixLenBits);
     suffixLenCheck.in <== in_body_suffix_len_padded_bytes * 8;
 

--- a/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
+++ b/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
@@ -3,6 +3,8 @@ pragma circom 2.1.5;
 include "@zk-email/circuits/helpers/sha.circom";
 include "@zk-email/circuits/helpers/extract.circom";
 
+include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
+
 template BodySuffixHasher(max_body_suffix_bytes) {
     assert(max_body_suffix_bytes % 64 == 0);
 

--- a/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
+++ b/circuits-circom/circuits/common-v2/body_suffix_hasher.circom
@@ -17,6 +17,14 @@ template BodySuffixHasher(max_body_suffix_bytes) {
     
     //-------Hash Body Suffix----------//
 
+    // Checking the range of body-suffix length.
+    // This check is crucial for the soundness of Sha256BytesPartial.
+    // For details, see:
+    // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44  
+    var suffixLenBits = ceil_log2(max_body_suffix_bytes * 8);
+    component suffixLenCheck = Num2Bits(suffixLenBits);
+    suffixLenCheck.in <== in_body_suffix_len_padded_bytes * 8;
+
     signal body_hash_bits[256] <== Sha256BytesPartial(max_body_suffix_bytes)(in_body_suffix_padded, in_body_suffix_len_padded_bytes, intermediate_hash);
 
     component bits2Num[32];

--- a/circuits-circom/circuits/garanti/garanti_registration.circom
+++ b/circuits-circom/circuits/garanti/garanti_registration.circom
@@ -46,6 +46,14 @@ template GarantiRegistrationEmail(max_header_bytes, max_body_bytes, n, k, pack_s
     // Assert padding is all zeroes
     AssertZeroes(max_body_bytes)(in_body_padded, in_body_len_padded_bytes + 1);
 
+    // Checking the range of the body length.
+    // This check is crucial for the soundness of Sha256BytesPartial.
+    // For details, see:
+    // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44  
+    var bodyLenBits = ceil_log2(max_body_bytes * 8);
+    component bodyLenCheck = Num2Bits(bodyLenBits);
+    bodyLenCheck.in <== in_body_len_padded_bytes * 8; 
+
     // This hashes the body after the precomputed SHA, and outputs the intermediate hash
     signal intermediate_hash_bits[256] <== Sha256BytesPartial(max_body_bytes)(in_body_padded, in_body_len_padded_bytes, precomputed_sha);
     signal intermediate_hash_bytes[32];

--- a/circuits-circom/circuits/garanti/garanti_registration.circom
+++ b/circuits-circom/circuits/garanti/garanti_registration.circom
@@ -13,6 +13,8 @@ include "./regexes/garanti_payer_details.circom";
 
 include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
 
+include "@zk-email/circuits/utils/functions.circom"; // needed for log2Ceil
+
 template GarantiRegistrationEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(n * k > 2048); // constraints for 2048 bit RSA
 
@@ -52,7 +54,7 @@ template GarantiRegistrationEmail(max_header_bytes, max_body_bytes, n, k, pack_s
     // This check is crucial for the soundness of Sha256BytesPartial.
     // For details, see:
     // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44  
-    var bodyLenBits = ceil_log2(max_body_bytes * 8);
+    var bodyLenBits = log2Ceil(max_body_bytes * 8);
     component bodyLenCheck = Num2Bits(bodyLenBits);
     bodyLenCheck.in <== in_body_len_padded_bytes * 8; 
 

--- a/circuits-circom/circuits/garanti/garanti_registration.circom
+++ b/circuits-circom/circuits/garanti/garanti_registration.circom
@@ -11,6 +11,8 @@ include "../common-v2/regexes/to_regex_v2.circom";
 include "./regexes/garanti_subject.circom";
 include "./regexes/garanti_payer_details.circom";
 
+include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
+
 template GarantiRegistrationEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(n * k > 2048); // constraints for 2048 bit RSA
 

--- a/circuits-circom/circuits/garanti/garanti_send.circom
+++ b/circuits-circom/circuits/garanti/garanti_send.circom
@@ -16,6 +16,7 @@ include "./regexes/garanti_payment_details.circom";
 include "./regexes/garanti_timestamp.circom";
 
 include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
+include "@zk-email/circuits/utils/functions.circom"; // needed for log2Ceil
 
 
 template GarantiSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
@@ -59,7 +60,7 @@ template GarantiSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     // This check is crucial for the soundness of Sha256BytesPartial.
     // For details, see:
     // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44 
-    var bodyLenBits = ceil_log2(max_body_bytes * 8);
+    var bodyLenBits = log2Ceil(max_body_bytes * 8);
     component bodyLenCheck = Num2Bits(bodyLenBits);
     bodyLenCheck.in <== in_body_len_padded_bytes * 8;
 

--- a/circuits-circom/circuits/garanti/garanti_send.circom
+++ b/circuits-circom/circuits/garanti/garanti_send.circom
@@ -15,6 +15,8 @@ include "./regexes/garanti_payer_details.circom";
 include "./regexes/garanti_payment_details.circom";
 include "./regexes/garanti_timestamp.circom";
 
+include "circomlib/circuits/bitify.circom"; // needed for Num2Bits
+
 
 template GarantiSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(n * k > 2048); // constraints for 2048 bit RSA

--- a/circuits-circom/circuits/garanti/garanti_send.circom
+++ b/circuits-circom/circuits/garanti/garanti_send.circom
@@ -53,6 +53,14 @@ template GarantiSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     // Assert padding is all zeroes
     AssertZeroes(max_body_bytes)(in_body_padded, in_body_len_padded_bytes + 1);
 
+    // Checking the range of the body length.
+    // This check is crucial for the soundness of Sha256BytesPartial.
+    // For details, see:
+    // https://github.com/zkemail/zk-email-verify/blob/b193cf0c760456b837b2bbcf7b2c72d5bb3f43c3/packages/circuits/lib/sha.circom#L44 
+    var bodyLenBits = ceil_log2(max_body_bytes * 8);
+    component bodyLenCheck = Num2Bits(bodyLenBits);
+    bodyLenCheck.in <== in_body_len_padded_bytes * 8;
+
     // This hashes the body after the precomputed SHA, and outputs the intermediate hash
     signal intermediate_hash_bits[256] <== Sha256BytesPartial(max_body_bytes)(in_body_padded, in_body_len_padded_bytes, precomputed_sha);
     signal intermediate_hash_bytes[32];


### PR DESCRIPTION
This pull request addresses a security issue caused by missing range checks on length signals passed into `Sha256BytesPartial`.

* \#428
  The `Sha256BytesPartial` template assumes that its `paddedInLength` input is bounded to `ceil(log₂(8 x maxByteLength))` bits. However, this assumption was not enforced in several templates, such as `BodySuffixHasher`, `GarantiRegistrationEmail`, and `GarantiSendEmail`. Malicious inputs to the padded length can bypass internal comparator constraints and produce incorrect SHA-256 outputs while still satisfying the circuit.

To resolve this, we explicitly add `Num2Bits` checks for the bit-width of the padded body lengths in each of these templates.

For full details, please refer to the linked issue.

Closes #428.