### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Specify node version...
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.15.0'
       - name: Enable Corepack

--- a/.github/workflows/contracts-domain.yml
+++ b/.github/workflows/contracts-domain.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Specify node version...
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.9.0'
       - name: Install Dependencies

--- a/.github/workflows/contracts-ramp.yml
+++ b/.github/workflows/contracts-ramp.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Specify node version...
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.15.0'
       - name: Install Dependencies


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.