### PR TITLE
feat: increase max amount length for Garanti Turkish Lira payments

### DIFF
--- a/circuits-circom/circuits/garanti/garanti_send.circom
+++ b/circuits-circom/circuits/garanti/garanti_send.circom
@@ -103,7 +103,7 @@ template GarantiSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     var max_payee_acc_num_packed_bytes = count_packed(max_payee_acc_num_len, pack_size);
     assert(max_payee_acc_num_packed_bytes < max_body_bytes);
 
-    var max_amount_len = 8; // Length of "2.000,00"; // TODO: What is the MAX amount?
+    var max_amount_len = 9; // Max amount format: "31.000,00" TRY. Based on max USDC amount of 100 USDC * ~31 TRY/USDC exchange rate. Turkish Lira uses dot as thousands separator and comma as decimal separator.
     var max_amount_packed_bytes = count_packed(max_amount_len, pack_size);
     assert(max_amount_packed_bytes < max_body_bytes);
 


### PR DESCRIPTION
This PR increases the max_amount_len from 8 to 9 characters in the Garanti send circuit to properly accommodate Turkish Lira payment amounts up to 31,000.00 TRY. 

The change is based on the maximum USDC amount of 100 USDC multiplied by the approximate exchange rate of 31 TRY/USDC, ensuring the circuit can handle the full range of supported payment amounts in Turkish Lira format (using dot as thousands separator and comma as decimal separator).