### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/circuit.yml
+++ b/.github/workflows/circuit.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-domain.yml
+++ b/.github/workflows/contracts-domain.yml
@@ -7,7 +7,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/contracts-ramp.yml
+++ b/.github/workflows/contracts-ramp.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Specify node version...
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0